### PR TITLE
Handle overflow by ending game

### DIFF
--- a/Assets/scripts/global/funcs.cs
+++ b/Assets/scripts/global/funcs.cs
@@ -25,12 +25,16 @@ public static class common_utils{
 
     public static string f2s(float num) {
         string format = "0.##";
-        if (Math.Abs(num) < 1000f) return num.ToString(format); 
+        if (float.IsNaN(num) || float.IsInfinity(num) || Math.Abs(num) >= consts.max_val){
+            statics.mngr_gameover.check_is_gameover();
+            return "0";
+        }
+        if (Math.Abs(num) < 1000f) return num.ToString(format);
         int magnitude = (int)Math.Floor(Math.Log10(Math.Abs(num)) / 3);
         magnitude = Math.Min(magnitude, consts.suffixes.Count - 1);
         float scaled = (float)(num / Math.Pow(1000f, magnitude));
         return scaled.ToString(format, CultureInfo.InvariantCulture) + consts.suffixes[magnitude];
-    }   
+    }
 
     public static List<string> f2s(List<float> nums) {
         List<string> res = new();

--- a/Assets/scripts/global/statics.cs
+++ b/Assets/scripts/global/statics.cs
@@ -110,11 +110,23 @@ public static class statics{
         }
 
         public static void check_is_gameover(){
-            if (mngr_balance.amount >= consts.max_val){
+            if (mngr_balance.amount >= consts.max_val
+            || mngr_cb.amount >= consts.max_val
+            || mngr_upgrs.gps >= consts.max_val){
                 is_gameover = true;
+
+                mngr_balance.amount = 0f;
+                mngr_balance.max_amount = 0f;
+                mngr_balance.on_val_change();
+
+                mngr_cb.amount = 0f;
+                mngr_cb.on_val_change();
+
+                mngr_upgrs.gps = 0f;
+                mngr_upgrs.act_ui(new(){"stats"});
+
                 act_ui();
                 save_module.save_gameover_status();
-                statics.mngr_upgrs.gps = 0f;
             }
         }
 


### PR DESCRIPTION
## Summary
- Prevent number formatting errors by triggering game over when balance, cacao beans, or GPS exceed float limits
- Reset critical values and show the game-over screen once overflow occurs
- Guard number-to-string conversion against overflow/NaN inputs

## Testing
- ⚠️ `dotnet test` *(command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b302e9af4883228811b57668505995