### PR TITLE
Animate tap bonus text transitions

### DIFF
--- a/Assets/Scenes/chocolate_clicker.unity
+++ b/Assets/Scenes/chocolate_clicker.unity
@@ -17637,6 +17637,8 @@ GameObject:
   - component: {fileID: 1077401232}
   - component: {fileID: 1077401231}
   - component: {fileID: 1077401230}
+  - component: {fileID: 1077401234}
+  - component: {fileID: 1077401233}
   m_Layer: 5
   m_Name: indicator_bonus
   m_TagString: Untagged
@@ -17774,6 +17776,39 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1077401228}
   m_CullTransparentMesh: 1
+--- !u!225 &1077401233
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1077401228}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0
+--- !u!95 &1077401234
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1077401228}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 9f8be490ecbfb1e44aa160afe8ac2d24, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
 --- !u!1 &1077549808
 GameObject:
   m_ObjectHideFlags: 0
@@ -38370,6 +38405,7 @@ MonoBehaviour:
   tutor_ach_win_bttn_anmtr: {fileID: 740481627}
   tutor_diamonds_anmtr: {fileID: 575539228}
   as_label_to_trigger_anmtr: {fileID: 67886607}
+  tap_indicator_bonus_txt_anmtr: {fileID: 1077401234}
   tap_indicator_anmtr: {fileID: 1741893067}
   prof_window_reset_bt_cg: {fileID: 595972697}
   tempering_reward_bttn_cg: {fileID: 123556886}

--- a/Assets/scripts/global/statics.cs
+++ b/Assets/scripts/global/statics.cs
@@ -1186,9 +1186,11 @@ public static class statics{
         static bool is_bonus_active = false;
         static Coroutine deactivate_coroutine;
         static Coroutine bonus_shake_coroutine;
+        static Coroutine bonus_txt_deactivate_coroutine;
         static Vector2 bonus_txt_initial_pos;
         static Vector3 bonus_txt_initial_euler;
         static bool bonus_txt_defaults_initialized = false;
+        static Animator bonus_txt_animator;
 
         public static void init(){
             val = 0f;
@@ -1196,10 +1198,12 @@ public static class statics{
             is_bonus_active = false;
             stop_bonus_shake();
             bonus_txt_defaults_initialized = false;
+            bonus_txt_deactivate_coroutine = null;
             if (deactivate_coroutine != null && statics.logic_module != null){
                 statics.logic_module.StopCoroutine(deactivate_coroutine);
                 deactivate_coroutine = null;
             }
+            bonus_txt_animator = null;
             if (urefs.tap_indicator_bonus_txt != null){
                 RectTransform bonus_rt = urefs.tap_indicator_bonus_txt.rectTransform;
                 if (bonus_rt != null){
@@ -1208,6 +1212,7 @@ public static class statics{
                     bonus_txt_defaults_initialized = true;
                     reset_bonus_text_transform();
                 }
+                bonus_txt_animator = urefs.tap_indicator_bonus_txt.GetComponent<Animator>();
                 urefs.tap_indicator_bonus_txt.text =
                     common_utils.f2s(consts.tap_indicator_bonus) + "x";
                 urefs.tap_indicator_bonus_txt.gameObject.SetActive(false);
@@ -1252,16 +1257,7 @@ public static class statics{
             bool should_show_bonus = val > consts.tap_indicator_bonus_threshold;
             if (should_show_bonus != is_bonus_active){
                 is_bonus_active = should_show_bonus;
-                if (urefs.tap_indicator_bonus_txt != null){
-                    urefs.tap_indicator_bonus_txt.gameObject.SetActive(is_bonus_active);
-                    handle_bonus_text_visibility(is_bonus_active);
-                }
-            }
-
-            if (!should_show_bonus && urefs.tap_indicator_bonus_txt != null
-                && urefs.tap_indicator_bonus_txt.gameObject.activeSelf){
-                urefs.tap_indicator_bonus_txt.gameObject.SetActive(false);
-                handle_bonus_text_visibility(false);
+                handle_bonus_text_visibility(is_bonus_active);
             }
         }
 
@@ -1298,7 +1294,18 @@ public static class statics{
             if (urefs.tap_indicator_bonus_txt == null)
                 return;
 
+            if (bonus_txt_deactivate_coroutine != null && statics.logic_module != null){
+                statics.logic_module.StopCoroutine(bonus_txt_deactivate_coroutine);
+                bonus_txt_deactivate_coroutine = null;
+            }
+
             if (visible){
+                GameObject bonus_go = urefs.tap_indicator_bonus_txt.gameObject;
+                if (!bonus_go.activeSelf)
+                    bonus_go.SetActive(true);
+                if (bonus_txt_animator != null && bonus_txt_animator.isActiveAndEnabled)
+                    bonus_txt_animator.Play("appear", 0, 0f);
+
                 if (!bonus_txt_defaults_initialized)
                     return;
                 stop_bonus_shake();
@@ -1306,6 +1313,16 @@ public static class statics{
                     bonus_shake_coroutine = statics.logic_module.StartCoroutine(shake_bonus_text());
             } else {
                 stop_bonus_shake();
+                if (bonus_txt_animator != null && statics.logic_module != null
+                    && bonus_txt_animator.isActiveAndEnabled
+                    && urefs.tap_indicator_bonus_txt.gameObject.activeInHierarchy){
+                    bonus_txt_deactivate_coroutine =
+                        statics.logic_module.StartCoroutine(disable_bonus_text_after_animation());
+                } else if (urefs.tap_indicator_bonus_txt.gameObject.activeSelf){
+                    if (bonus_txt_animator != null && bonus_txt_animator.isActiveAndEnabled)
+                        bonus_txt_animator.Play("disappear", 0, 0f);
+                    urefs.tap_indicator_bonus_txt.gameObject.SetActive(false);
+                }
             }
         }
 
@@ -1360,6 +1377,22 @@ public static class statics{
             if (urefs.tap_indicator_go != null)
                 urefs.tap_indicator_go.SetActive(false);
             deactivate_coroutine = null;
+        }
+
+        static IEnumerator disable_bonus_text_after_animation(){
+            if (bonus_txt_animator != null)
+                bonus_txt_animator.Play("disappear", 0, 0f);
+
+            if (bonus_txt_animator != null
+                && bonus_txt_animator.gameObject.activeInHierarchy
+                && bonus_txt_animator.isActiveAndEnabled){
+                yield return common_utils.wait_until_state_end(bonus_txt_animator, "disappear");
+            }
+
+            if (urefs.tap_indicator_bonus_txt != null)
+                urefs.tap_indicator_bonus_txt.gameObject.SetActive(false);
+
+            bonus_txt_deactivate_coroutine = null;
         }
     }
 

--- a/Assets/scripts/global/statics.cs
+++ b/Assets/scripts/global/statics.cs
@@ -1203,7 +1203,7 @@ public static class statics{
                 statics.logic_module.StopCoroutine(deactivate_coroutine);
                 deactivate_coroutine = null;
             }
-            bonus_txt_animator = null;
+            bonus_txt_animator = urefs.tap_indicator_bonus_txt_anmtr;
             if (urefs.tap_indicator_bonus_txt != null){
                 RectTransform bonus_rt = urefs.tap_indicator_bonus_txt.rectTransform;
                 if (bonus_rt != null){
@@ -1212,7 +1212,6 @@ public static class statics{
                     bonus_txt_defaults_initialized = true;
                     reset_bonus_text_transform();
                 }
-                bonus_txt_animator = urefs.tap_indicator_bonus_txt.GetComponent<Animator>();
                 urefs.tap_indicator_bonus_txt.text =
                     common_utils.f2s(consts.tap_indicator_bonus) + "x";
                 urefs.tap_indicator_bonus_txt.gameObject.SetActive(false);

--- a/Assets/scripts/global/urefs.cs
+++ b/Assets/scripts/global/urefs.cs
@@ -215,7 +215,7 @@ public static class urefs{
         tutor_arts_panel_bttn_bcc,
         tutor_arts_discover_bcc;
 
-    public static Animator 
+    public static Animator
         ad_button_anmtr,
         ach_noft_anmtr,
         as_bt_anmtr,
@@ -241,6 +241,7 @@ public static class urefs{
         tutor_ach_win_bttn_anmtr,
         tutor_diamonds_anmtr,
         as_label_to_trigger_anmtr,
+        tap_indicator_bonus_txt_anmtr,
         tap_indicator_anmtr;
 
     public static CanvasGroup

--- a/Assets/scripts/inits/urefs_init.cs
+++ b/Assets/scripts/inits/urefs_init.cs
@@ -245,6 +245,7 @@ public class urefs_init : MonoBehaviour{
         tutor_ach_win_bttn_anmtr,
         tutor_diamonds_anmtr,
         as_label_to_trigger_anmtr,
+        tap_indicator_bonus_txt_anmtr,
         tap_indicator_anmtr;
 
     public CanvasGroup


### PR DESCRIPTION
## Summary
- play the tap indicator bonus text appear animation whenever it is shown
- wait for the disappear animation to finish before deactivating the bonus text
- centralize animator handling with coroutine cleanup to avoid interrupted transitions

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68d1135fec508322a1a3589a83502480