### PR TITLE
Restrict chocolate generation to indicator bonus

### DIFF
--- a/Assets/Scenes/chocolate_clicker.unity
+++ b/Assets/Scenes/chocolate_clicker.unity
@@ -38170,6 +38170,9 @@ MonoBehaviour:
   combo_tap_clr:
     serializedVersion: 2
     rgba: 2664179
+  indicator_bonus_tap_clr:
+    serializedVersion: 2
+    rgba: 3048139
   active_upgr_clr:
     serializedVersion: 2
     rgba: 4290302944

--- a/Assets/Scenes/chocolate_clicker.unity
+++ b/Assets/Scenes/chocolate_clicker.unity
@@ -38172,7 +38172,7 @@ MonoBehaviour:
     rgba: 2664179
   indicator_bonus_tap_clr:
     serializedVersion: 2
-    rgba: 3048139
+    rgba: 35071
   active_upgr_clr:
     serializedVersion: 2
     rgba: 4290302944

--- a/Assets/scripts/global/consts.cs
+++ b/Assets/scripts/global/consts.cs
@@ -377,6 +377,7 @@ public static class consts{
         default_tap_clr,
         crit_tap_clr,
         combo_tap_clr,
+        indicator_bonus_tap_clr,
         active_upgr_clr,
         not_active_upgr_clr;
 }

--- a/Assets/scripts/global/statics.cs
+++ b/Assets/scripts/global/statics.cs
@@ -1535,7 +1535,7 @@ public static class statics{
             .GetComponent<tap_number_refs>();
             string text = common_utils.f2s((float)Math.Truncate(number));
             if (has_indicator_bonus){
-                text += "(x" + common_utils.f2s(indicator_multiplier) + ")";
+                text += "(" + common_utils.f2s(indicator_multiplier) + "x)";
                 temp1.txt.color = consts.indicator_bonus_tap_clr;
             } else {
                 temp1.txt.color = clr;

--- a/Assets/scripts/global/statics.cs
+++ b/Assets/scripts/global/statics.cs
@@ -1535,7 +1535,7 @@ public static class statics{
             .GetComponent<tap_number_refs>();
             string text = common_utils.f2s((float)Math.Truncate(number));
             if (has_indicator_bonus){
-                text += "(" + common_utils.f2s(indicator_multiplier) + "x)";
+                text += " (" + common_utils.f2s(indicator_multiplier) + "x)";
                 temp1.txt.color = consts.indicator_bonus_tap_clr;
             } else {
                 temp1.txt.color = clr;

--- a/Assets/scripts/global/statics.cs
+++ b/Assets/scripts/global/statics.cs
@@ -1545,9 +1545,12 @@ public static class statics{
 
         public static void on_tap(){
             mngr_tutor.try_close_tutor("tutor_click");
-            chocogen.gen();
             mngr_indicator.on_click();
             float indicator_multiplier = mngr_indicator.get_tap_multiplier();
+            bool has_indicator_bonus = indicator_multiplier > 1f;
+            if (has_indicator_bonus){
+                chocogen.gen();
+            }
             if (UnityEngine.Random.value < diamond_ch){
                 mngr_diamonds.amount++;
                 mngr_diamonds.on_val_change();
@@ -1581,7 +1584,6 @@ public static class statics{
             }
             temp1 *= indicator_multiplier;
             temp1 = (float)Math.Truncate(temp1);
-            bool has_indicator_bonus = indicator_multiplier > 1f;
             change_float_number_params(temp1, tap_clr, has_indicator_bonus, indicator_multiplier);
 
             mngr_balance.amount += temp1; 

--- a/Assets/scripts/global/statics.cs
+++ b/Assets/scripts/global/statics.cs
@@ -1525,11 +1525,22 @@ public static class statics{
             }
         }
 
-        public static void change_float_number_params(float number, Color32 clr){
+        public static void change_float_number_params(
+            float number,
+            Color32 clr,
+            bool has_indicator_bonus,
+            float indicator_multiplier
+        ){
             var temp1 = UnityEngine.Object.Instantiate(consts.click_num_pf, urefs.chocolate_rt)
             .GetComponent<tap_number_refs>();
-            temp1.txt.text = common_utils.f2s((float)Math.Truncate(number));
-            temp1.txt.color = clr;
+            string text = common_utils.f2s((float)Math.Truncate(number));
+            if (has_indicator_bonus){
+                text += "(x" + common_utils.f2s(indicator_multiplier) + ")";
+                temp1.txt.color = consts.indicator_bonus_tap_clr;
+            } else {
+                temp1.txt.color = clr;
+            }
+            temp1.txt.text = text;
         }
 
         public static void on_tap(){
@@ -1570,7 +1581,8 @@ public static class statics{
             }
             temp1 *= indicator_multiplier;
             temp1 = (float)Math.Truncate(temp1);
-            change_float_number_params(temp1, tap_clr);
+            bool has_indicator_bonus = indicator_multiplier > 1f;
+            change_float_number_params(temp1, tap_clr, has_indicator_bonus, indicator_multiplier);
 
             mngr_balance.amount += temp1; 
             mngr_balance.on_val_change();

--- a/Assets/scripts/inits/consts_init.cs
+++ b/Assets/scripts/inits/consts_init.cs
@@ -61,7 +61,7 @@ public class consts_init: MonoBehaviour{
         quest_completion_ac,
         typewrite_ac;
 
-    public Color32 
+    public Color32
         active_skin_bttn_clr,
         not_active_skin_bttn_clr,
         active_shop_bt_clr,
@@ -71,6 +71,7 @@ public class consts_init: MonoBehaviour{
         default_tap_clr,
         crit_tap_clr,
         combo_tap_clr,
+        indicator_bonus_tap_clr,
         active_upgr_clr,
         not_active_upgr_clr;
 }


### PR DESCRIPTION
## Summary
- only spawn chocolate visuals on tap when the indicator bonus is active
- ensure indicator bonus state is calculated before handling tap rewards

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d14bd60ac48322b51c2c664a26992a