### PR TITLE
Use bonus tap popup prefab

### DIFF
--- a/Assets/Scenes/chocolate_clicker.unity
+++ b/Assets/Scenes/chocolate_clicker.unity
@@ -38119,6 +38119,7 @@ MonoBehaviour:
   upgr_slot_pf: {fileID: 4793260231359470432, guid: 7334289bafaa3b94aba50f51bc90ae96, type: 3}
   art_slot_pf: {fileID: 4793260231359470432, guid: fb8eebb9203bc6246a7f47db451e4142, type: 3}
   click_num_pf: {fileID: 7736573471094483815, guid: c8e11f15c23915b43b7d2801395d2ece, type: 3}
+  tap_popup_bonus_ind_pf: {fileID: 7736573471094483815, guid: 18955d4cab3af614cbd26401bb39501d, type: 3}
   chocofall_pf: {fileID: 908331211877498039, guid: d58d7e9f453d6c446b5a779794232ea9, type: 3}
   ach_slot_pf: {fileID: 8369392294980996517, guid: 32e4864ed639de04298bae2870b49bbb, type: 3}
   skin_slot_pf: {fileID: 5961218400834735748, guid: 2db579c8e163a5645930d4216c9d06bc, type: 3}

--- a/Assets/prefabs/tap_popup_bonus_ind.prefab
+++ b/Assets/prefabs/tap_popup_bonus_ind.prefab
@@ -179,7 +179,6 @@ GameObject:
   - component: {fileID: 7267551321192004341}
   - component: {fileID: 2569855943390822321}
   - component: {fileID: 6729588071463605177}
-  - component: {fileID: 6394074027395906850}
   - component: {fileID: 2379355821113696897}
   m_Layer: 5
   m_Name: tap_popup_bonus_ind
@@ -304,23 +303,6 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!114 &6394074027395906850
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7770351030774396631}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ba7276682a852414abf30b6a6ab6969d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  txt: {fileID: 6729588071463605177}
-  multiplier_txt: {fileID: 0}
-  rt: {fileID: 7267551321192004341}
-  speed: 0
-  elapsedTime: 0
 --- !u!114 &2379355821113696897
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/scripts/global/consts.cs
+++ b/Assets/scripts/global/consts.cs
@@ -337,9 +337,10 @@ public static class consts{
     public static List<Sprite> gen_on_click_sprites;
 
     public static GameObject
-        upgr_slot_pf, 
-        art_slot_pf, 
-        click_num_pf, 
+        upgr_slot_pf,
+        art_slot_pf,
+        click_num_pf,
+        tap_popup_bonus_ind_pf,
         chocofall_pf,
         ach_slot_pf,
         skin_slot_pf,

--- a/Assets/scripts/global/statics.cs
+++ b/Assets/scripts/global/statics.cs
@@ -1525,11 +1525,20 @@ public static class statics{
             }
         }
 
-        public static void change_float_number_params(float number, Color32 clr){
-            var temp1 = UnityEngine.Object.Instantiate(consts.click_num_pf, urefs.chocolate_rt)
-            .GetComponent<tap_number_refs>();
+        public static void change_float_number_params(float number, Color32 clr, bool is_indicator_bonus_active){
+            GameObject popup_prefab = consts.click_num_pf;
+            if (is_indicator_bonus_active && consts.tap_popup_bonus_ind_pf != null){
+                popup_prefab = consts.tap_popup_bonus_ind_pf;
+            }
+
+            var temp1 = UnityEngine.Object.Instantiate(popup_prefab, urefs.chocolate_rt)
+                .GetComponent<tap_number_refs>();
             temp1.txt.text = common_utils.f2s((float)Math.Truncate(number));
             temp1.txt.color = clr;
+            if (is_indicator_bonus_active && temp1.multiplier_txt != null){
+                temp1.multiplier_txt.text = common_utils.f2s(consts.tap_indicator_bonus) + "x";
+                temp1.multiplier_txt.color = clr;
+            }
         }
 
         public static void on_tap(){
@@ -1570,7 +1579,8 @@ public static class statics{
             }
             temp1 *= indicator_multiplier;
             temp1 = (float)Math.Truncate(temp1);
-            change_float_number_params(temp1, tap_clr);
+            bool is_indicator_bonus_active = indicator_multiplier > 1f;
+            change_float_number_params(temp1, tap_clr, is_indicator_bonus_active);
 
             mngr_balance.amount += temp1; 
             mngr_balance.on_val_change();

--- a/Assets/scripts/inits/consts_init.cs
+++ b/Assets/scripts/inits/consts_init.cs
@@ -31,9 +31,10 @@ public class consts_init: MonoBehaviour{
     public List<Sprite> gen_on_click_sprites;
 
     public GameObject
-        upgr_slot_pf, 
-        art_slot_pf, 
-        click_num_pf, 
+        upgr_slot_pf,
+        art_slot_pf,
+        click_num_pf,
+        tap_popup_bonus_ind_pf,
         chocofall_pf,
         ach_slot_pf,
         skin_slot_pf,

--- a/Assets/scripts/samples/tap_number_refs.cs
+++ b/Assets/scripts/samples/tap_number_refs.cs
@@ -29,6 +29,11 @@ public class tap_number_refs: MonoBehaviour{
             Color temp1 = txt.color;
             temp1.a = 1 - elapsedTime/consts.duration_tap_number;
             txt.color = temp1;
+            if (multiplier_txt != null){
+                Color multiplier_clr = multiplier_txt.color;
+                multiplier_clr.a = temp1.a;
+                multiplier_txt.color = multiplier_clr;
+            }
         } else {
             Destroy(gameObject);
         }


### PR DESCRIPTION
## Summary
- add a constant hook for the new tap indicator bonus popup prefab
- spawn the bonus popup and populate its multiplier text when the indicator bonus is active
- keep the bonus multiplier text alpha in sync with the popup fade animation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d28d1af8908322843f4a2c8e126d03