### PR TITLE
Trigger chocorain only during indicator bonus

### DIFF
--- a/Assets/scripts/global/consts.cs
+++ b/Assets/scripts/global/consts.cs
@@ -41,7 +41,7 @@ public static class consts{
         x1_cf_crd,
         x2_cf_crd,
         y_cf_crd,
-        cf_acceleration = 440f,
+        cf_speed = 440f,
         cf_min_size = 0.6f,
         cf_max_size = 0.9f,
         cf_sample_lifetime,

--- a/Assets/scripts/global/consts.cs
+++ b/Assets/scripts/global/consts.cs
@@ -41,11 +41,11 @@ public static class consts{
         x1_cf_crd,
         x2_cf_crd,
         y_cf_crd,
-        cf_speed = 440f,
+        cf_speed = 1500f,
         cf_min_size = 0.6f,
         cf_max_size = 0.9f,
         cf_sample_lifetime,
-        cf_spawn_interval = 0.2f,
+        cf_spawn_interval = 0.15f,
         cf_min_alpha = 0.7f,
 
         //discover

--- a/Assets/scripts/global/statics.cs
+++ b/Assets/scripts/global/statics.cs
@@ -1077,16 +1077,6 @@ public static class statics{
             urefs.as_circle_timer_go.SetActive(false);
         }
 
-        public static IEnumerator start_cf(){
-            while (statics.mngr_prof.as_activated){
-                GameObject cf_instance_temp = 
-                    UnityEngine.Object.Instantiate(consts.chocofall_pf, urefs.cfrd_zone_rt);
-
-                UnityEngine.Object.Destroy(cf_instance_temp, consts.cf_sample_lifetime);
-                yield return new WaitForSeconds(consts.cf_spawn_interval);
-            }
-        }
-
         public static IEnumerator try_activate_as(){
             if (consts.profs_data[cur_prof_nm].grade != 0){
                 logic_module.StartCoroutine(show_as_label());
@@ -1098,7 +1088,6 @@ public static class statics{
                 as_activated = true;
                 save_module.save_as_status();
                 change_params_for_as();
-                logic_module.StartCoroutine(start_cf());
                 yield return start_as_timer();
                 as_activated = false;
                 save_module.save_as_status();
@@ -1187,6 +1176,7 @@ public static class statics{
         static Coroutine deactivate_coroutine;
         static Coroutine bonus_shake_coroutine;
         static Coroutine bonus_txt_deactivate_coroutine;
+        static Coroutine chocorain_coroutine;
         static Vector2 bonus_txt_initial_pos;
         static Vector3 bonus_txt_initial_euler;
         static bool bonus_txt_defaults_initialized = false;
@@ -1197,6 +1187,7 @@ public static class statics{
             is_visible = false;
             is_bonus_active = false;
             stop_bonus_shake();
+            stop_chocorain();
             bonus_txt_defaults_initialized = false;
             bonus_txt_deactivate_coroutine = null;
             if (deactivate_coroutine != null && statics.logic_module != null){
@@ -1257,6 +1248,7 @@ public static class statics{
             if (should_show_bonus != is_bonus_active){
                 is_bonus_active = should_show_bonus;
                 handle_bonus_text_visibility(is_bonus_active);
+                update_chocorain_state();
             }
         }
 
@@ -1392,6 +1384,38 @@ public static class statics{
                 urefs.tap_indicator_bonus_txt.gameObject.SetActive(false);
 
             bonus_txt_deactivate_coroutine = null;
+        }
+
+        static void update_chocorain_state(){
+            if (statics.logic_module == null){
+                stop_chocorain();
+                return;
+            }
+
+            if (is_bonus_active){
+                if (chocorain_coroutine == null)
+                    chocorain_coroutine = statics.logic_module.StartCoroutine(run_chocorain());
+            } else {
+                stop_chocorain();
+            }
+        }
+
+        static void stop_chocorain(){
+            if (chocorain_coroutine != null && statics.logic_module != null)
+                statics.logic_module.StopCoroutine(chocorain_coroutine);
+            chocorain_coroutine = null;
+        }
+
+        static IEnumerator run_chocorain(){
+            while (is_bonus_active){
+                GameObject cf_instance_temp =
+                    UnityEngine.Object.Instantiate(consts.chocofall_pf, urefs.cfrd_zone_rt);
+
+                UnityEngine.Object.Destroy(cf_instance_temp, consts.cf_sample_lifetime);
+                yield return new WaitForSeconds(consts.cf_spawn_interval);
+            }
+
+            chocorain_coroutine = null;
         }
     }
 

--- a/Assets/scripts/inits/consts_init.cs
+++ b/Assets/scripts/inits/consts_init.cs
@@ -19,8 +19,8 @@ public class consts_init: MonoBehaviour{
         consts.y_cf_crd = 
             + urefs.cfrd_zone_rt.rect.height/2 + cf_pf_height_temp/2;
 
-        consts.cf_sample_lifetime = 
-            Mathf.Sqrt(2f * (urefs.cfrd_zone_rt.rect.height + cf_pf_height_temp) / consts.cf_acceleration);
+        consts.cf_sample_lifetime =
+            (urefs.cfrd_zone_rt.rect.height + cf_pf_height_temp) / consts.cf_speed;
         
         consts.x1_nmbr_tap_crd = - urefs.chocolate_rt.rect.width/2;
         consts.x2_nmbr_tap_crd = + urefs.chocolate_rt.rect.width/2;

--- a/Assets/scripts/samples/chocofall.cs
+++ b/Assets/scripts/samples/chocofall.cs
@@ -5,8 +5,7 @@ public class chocofall : MonoBehaviour{
     public Image
         im;
 
-    public float 
-        velocity = 0f,
+    public float
         cur_lifetime = 0f;
     
     public RectTransform
@@ -22,8 +21,7 @@ public class chocofall : MonoBehaviour{
 
     void Update(){
         cur_lifetime += Time.deltaTime;
-        rt.anchoredPosition -= new Vector2(0, velocity * Time.deltaTime);
-        velocity += consts.cf_acceleration * Time.deltaTime;
+        rt.anchoredPosition -= new Vector2(0, consts.cf_speed * Time.deltaTime);
         var temp = im.color;
         temp.a = Mathf.Lerp(1f, consts.cf_min_alpha, cur_lifetime/consts.cf_sample_lifetime);
         im.color = temp;


### PR DESCRIPTION
## Summary
- remove the chocorain effect from the active skill activation flow
- wire the chocorain spawning coroutine to the tap indicator bonus state so it only runs while the bonus is active

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68d2b7ac1c188322a68bf3dc9fab9394