### PR TITLE
Adjust golden chocolate wave spawning delays

### DIFF
--- a/Assets/scripts/global/consts.cs
+++ b/Assets/scripts/global/consts.cs
@@ -129,6 +129,8 @@ public static class consts{
         //golden chocolate
         golden_spawn_mean_delay = 180f,
         golden_spawn_pity = 300f,
+        golden_spawn_wave_min_delay = 0.1f, //minimum delay between chocolates within a wave
+        golden_spawn_wave_max_delay = 0.5f, //maximum delay between chocolates within a wave
         golden_chocolate_move_speed = 420f,
         golden_chocolate_rotation_speed = 120f,
         golden_reward_gps_fraction = 30f, //seconds worth of current chocolate per second

--- a/Assets/scripts/global/statics.cs
+++ b/Assets/scripts/global/statics.cs
@@ -717,7 +717,7 @@ public static class statics{
                 time_since_last_spawn += Time.deltaTime;
                 if ((next_spawn_delay > 0f && time_since_last_spawn >= next_spawn_delay)
                     || time_since_last_spawn >= consts.golden_spawn_pity){
-                    spawn_wave();
+                    yield return spawn_wave();
                     time_since_last_spawn = 0f;
                     next_spawn_delay = get_next_delay();
                 }
@@ -725,9 +725,30 @@ public static class statics{
             }
         }
 
-        static void spawn_wave(){
-            for (int i = 0; i < consts.golden_spawn_wave_count; i++)
+        static IEnumerator spawn_wave(){
+            int wave_count = consts.golden_spawn_wave_count;
+            if (wave_count <= 0)
+                yield break;
+
+            spawn_single();
+
+            if (wave_count <= 1)
+                yield break;
+
+            float min_delay = consts.golden_spawn_wave_min_delay;
+            float max_delay = consts.golden_spawn_wave_max_delay;
+
+            if (max_delay < min_delay){
+                float temp = min_delay;
+                min_delay = max_delay;
+                max_delay = temp;
+            }
+
+            for (int i = 1; i < wave_count; i++){
+                float delay = UnityEngine.Random.Range(min_delay, max_delay);
+                yield return new WaitForSeconds(delay);
                 spawn_single();
+            }
         }
 
         static void spawn_single(){


### PR DESCRIPTION
## Summary
- add configurable minimum and maximum delays between golden chocolates in a wave
- convert the golden chocolate wave spawner into a coroutine that spaces out spawns using the new delay range
- ensure the spawn loop waits for wave completion while respecting zero or negative wave counts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d30c7d25e483229a213d63c80cc084