### PR TITLE
Implement GPS tick coroutine and gain text animation

### DIFF
--- a/Assets/Scenes/chocolate_clicker.unity
+++ b/Assets/Scenes/chocolate_clicker.unity
@@ -11180,7 +11180,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &694403355
 RectTransform:
   m_ObjectHideFlags: 0
@@ -11197,9 +11197,9 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
-  m_AnchoredPosition: {x: 97.7, y: -3.6}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 17.4, y: -4.7}
+  m_SizeDelta: {x: 158.94, y: 82.23}
+  m_Pivot: {x: 0, y: 0.5}
 --- !u!95 &694403356
 Animator:
   serializedVersion: 5
@@ -11290,7 +11290,7 @@ MonoBehaviour:
   m_fontSizeMax: 72
   m_fontStyle: 0
   m_HorizontalAlignment: 1
-  m_VerticalAlignment: 256
+  m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
   m_wordSpacing: 0
@@ -18117,7 +18117,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1077401229
 RectTransform:
   m_ObjectHideFlags: 0
@@ -18135,7 +18135,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: -827.23, y: -127}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 83.1, y: 104.66}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1077401230
 MonoBehaviour:
@@ -30409,7 +30409,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1741893066
 RectTransform:
   m_ObjectHideFlags: 0
@@ -37255,9 +37255,9 @@ RectTransform:
   - {fileID: 694403355}
   m_Father: {fileID: 453307978}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -218.08, y: 427.73}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 692.90015, y: -100}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2118950931
@@ -38888,6 +38888,7 @@ MonoBehaviour:
   prof_window_reset_price_text_txt: {fileID: 1223568552}
   prof_window_reset_class_text_txt: {fileID: 2118375109}
   balance_text_txt: {fileID: 2118950931}
+  balance_gain_txt_txt: {fileID: 694403358}
   as_numbers_timer_txt: {fileID: 1160771689}
   stats_upgrs_text_txt: {fileID: 930984932}
   stats_arts_text_txt: {fileID: 1974855918}
@@ -39005,6 +39006,7 @@ MonoBehaviour:
   tap_indicator_anmtr: {fileID: 1741893067}
   glowing_choco_anmtr: {fileID: 1215760112}
   levelup_banner_anmtr: {fileID: 1825832167}
+  balance_gain_txt_anmtr: {fileID: 694403356}
   prof_window_reset_bt_cg: {fileID: 595972697}
   tempering_reward_bttn_cg: {fileID: 123556886}
   open_prof_win_bttn_cg: {fileID: 931681612}

--- a/Assets/anim_ctrl/gain_txt.controller
+++ b/Assets/anim_ctrl/gain_txt.controller
@@ -41,8 +41,8 @@ AnimatorStateTransition:
   serializedVersion: 3
   m_TransitionDuration: 0
   m_TransitionOffset: 0
-  m_ExitTime: 0.75
-  m_HasExitTime: 0
+  m_ExitTime: 0
+  m_HasExitTime: 1
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
@@ -137,9 +137,9 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 1
   serializedVersion: 3
-  m_TransitionDuration: 0.25
+  m_TransitionDuration: 0
   m_TransitionOffset: 0
-  m_ExitTime: 0.75
+  m_ExitTime: 0
   m_HasExitTime: 1
   m_HasFixedDuration: 1
   m_InterruptionSource: 0

--- a/Assets/anim_ctrl/lvlup_banner.controller
+++ b/Assets/anim_ctrl/lvlup_banner.controller
@@ -39,7 +39,7 @@ AnimatorStateMachine:
     m_Position: {x: 280, y: 160, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 6910217025840721140}
-    m_Position: {x: 560, y: 160, z: 0}
+    m_Position: {x: 563.94385, y: 175.90457, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions: []
   m_EntryTransitions: []
@@ -106,7 +106,7 @@ AnimatorState:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: appear
-  m_Speed: 2
+  m_Speed: 1
   m_CycleOffset: 0
   m_Transitions: []
   m_StateMachineBehaviours: []
@@ -132,10 +132,9 @@ AnimatorState:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: disappear
-  m_Speed: -0.7
+  m_Speed: -3
   m_CycleOffset: 0
-  m_Transitions:
-  - {fileID: -4426309502530481221}
+  m_Transitions: []
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0

--- a/Assets/scripts/global/logic.cs
+++ b/Assets/scripts/global/logic.cs
@@ -34,12 +34,10 @@ public class logic_module : MonoBehaviour{
         statics.logic_module.StartCoroutine(save_module.init());
 
         StartCoroutine(common_utils.do_every_second());
+        statics.mngr_balance.ensure_gps_income_loop();
     }
 
-    void Update(){ 
-        statics.mngr_balance.amount += statics.mngr_upgrs.gps * Time.deltaTime;
-        statics.mngr_balance.on_val_change();
-
+    void Update(){
         statics.mngr_indicator.update(Time.deltaTime);
 
         urefs.sun_tr.Rotate(0,0, 6f * Time.deltaTime);

--- a/Assets/scripts/global/statics.cs
+++ b/Assets/scripts/global/statics.cs
@@ -672,8 +672,11 @@ public static class statics{
             amount = 0f,
             max_amount = 0f;
 
+        static Coroutine gps_income_coroutine;
+
         public static void init(){
             act_ui();
+            start_gps_income_loop();
         }
 
         public static void on_val_change(){
@@ -681,6 +684,67 @@ public static class statics{
             mngr_tap.act_ui(new(){"alpha"});
             mngr_upgrs.act_ui(new(){"alpha"});
             act_ui();
+
+            if (gps_income_coroutine == null)
+                start_gps_income_loop();
+        }
+
+        public static void ensure_gps_income_loop(){
+            if (gps_income_coroutine == null)
+                start_gps_income_loop();
+        }
+
+        static void start_gps_income_loop(){
+            if (statics.logic_module == null)
+                return;
+
+            if (gps_income_coroutine != null)
+                statics.logic_module.StopCoroutine(gps_income_coroutine);
+
+            gps_income_coroutine = statics.logic_module.StartCoroutine(gps_income_loop());
+        }
+
+        static IEnumerator gps_income_loop(){
+            WaitForSeconds wait = new WaitForSeconds(1f);
+
+            while (true){
+                yield return wait;
+
+                float gps_value = statics.mngr_upgrs.gps;
+                if (gps_value <= 0f){
+                    if (urefs.balance_gain_txt_txt != null){
+                        GameObject gain_go = urefs.balance_gain_txt_txt.gameObject;
+                        if (gain_go.activeSelf)
+                            gain_go.SetActive(false);
+                    }
+                    continue;
+                }
+
+                float gps_to_display = (float)Math.Truncate(gps_value);
+                if (urefs.balance_gain_txt_txt != null){
+                    urefs.balance_gain_txt_txt.text =
+                        "+" + common_utils.f2s(gps_to_display) + " coins/sec";
+                }
+
+                GameObject gain_go_temp = urefs.balance_gain_txt_txt != null
+                    ? urefs.balance_gain_txt_txt.gameObject
+                    : null;
+
+                if (gain_go_temp != null){
+                    if (gain_go_temp.activeSelf)
+                        gain_go_temp.SetActive(false);
+                    gain_go_temp.SetActive(true);
+                }
+
+                if (urefs.balance_gain_txt_anmtr != null){
+                    yield return common_utils.wait_until_state_end(urefs.balance_gain_txt_anmtr, "appear");
+                } else {
+                    yield return null;
+                }
+
+                amount += gps_value;
+                on_val_change();
+            }
         }
 
         public static void clear_balance(){

--- a/Assets/scripts/global/statics.cs
+++ b/Assets/scripts/global/statics.cs
@@ -723,7 +723,7 @@ public static class statics{
                 float gps_to_display = (float)Math.Truncate(gps_value);
                 if (urefs.balance_gain_txt_txt != null){
                     urefs.balance_gain_txt_txt.text =
-                        "+" + common_utils.f2s(gps_to_display) + " coins/sec";
+                        "+" + common_utils.f2s(gps_to_display);
                 }
 
                 GameObject gain_go_temp = urefs.balance_gain_txt_txt != null
@@ -731,8 +731,6 @@ public static class statics{
                     : null;
 
                 if (gain_go_temp != null){
-                    if (gain_go_temp.activeSelf)
-                        gain_go_temp.SetActive(false);
                     gain_go_temp.SetActive(true);
                 }
 
@@ -744,6 +742,9 @@ public static class statics{
 
                 amount += gps_value;
                 on_val_change();
+
+                yield return common_utils.wait_until_state_end(urefs.balance_gain_txt_anmtr, "disappear");
+                gain_go_temp.SetActive(false);   
             }
         }
 

--- a/Assets/scripts/global/urefs.cs
+++ b/Assets/scripts/global/urefs.cs
@@ -118,6 +118,7 @@ public static class urefs{
         prof_window_reset_price_text_txt,
         prof_window_reset_class_text_txt,
         balance_text_txt,
+        balance_gain_txt_txt,
         as_numbers_timer_txt,
         stats_upgrs_text_txt,
         stats_arts_text_txt,
@@ -248,7 +249,8 @@ public static class urefs{
         tap_indicator_bonus_txt_anmtr,
         tap_indicator_anmtr,
         glowing_choco_anmtr,
-        levelup_banner_anmtr;
+        levelup_banner_anmtr,
+        balance_gain_txt_anmtr;
 
     public static CanvasGroup
         prof_window_reset_bt_cg,

--- a/Assets/scripts/inits/urefs_init.cs
+++ b/Assets/scripts/inits/urefs_init.cs
@@ -122,6 +122,7 @@ public class urefs_init : MonoBehaviour{
         prof_window_reset_price_text_txt,
         prof_window_reset_class_text_txt,
         balance_text_txt,
+        balance_gain_txt_txt,
         as_numbers_timer_txt,
         stats_upgrs_text_txt,
         stats_arts_text_txt,
@@ -252,7 +253,8 @@ public class urefs_init : MonoBehaviour{
         tap_indicator_bonus_txt_anmtr,
         tap_indicator_anmtr,
         glowing_choco_anmtr,
-        levelup_banner_anmtr;
+        levelup_banner_anmtr,
+        balance_gain_txt_anmtr;
 
     public CanvasGroup
         prof_window_reset_bt_cg,


### PR DESCRIPTION
## Summary
- update the logic module to trigger the balance GPS coroutine instead of frame-based income
- add a coroutine in the balance manager to update the gain text, wait for its animation, and apply GPS income once per second
- expose the gain text and animator references through urefs so the coroutine can control the animation

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68d436ef5f6c8322b4e74c5076c80859