### PR TITLE
Add XP rewards for upgrade purchases

### DIFF
--- a/Assets/scripts/global/classes.cs
+++ b/Assets/scripts/global/classes.cs
@@ -260,7 +260,7 @@ public class upgr{
 
             float xp_reward = price_old_temp * consts.xp_purchase_fraction;
             if (xp_reward > 0f){
-                statics.mngr_xp.add(xp_reward);
+                statics.mngr_xp.add((float)Math.Truncate(xp_reward));
                 statics.mngr_xp.act_ui();
             }
 

--- a/Assets/scripts/global/classes.cs
+++ b/Assets/scripts/global/classes.cs
@@ -258,6 +258,12 @@ public class upgr{
             statics.mngr_balance.amount -= price_real;
             statics.mngr_balance.on_val_change();
 
+            float xp_reward = price_old_temp * consts.xp_purchase_fraction;
+            if (xp_reward > 0f){
+                statics.mngr_xp.add(xp_reward);
+                statics.mngr_xp.act_ui();
+            }
+
             urefs.sound_asrc_as.PlayOneShot(consts.currency);
             statics.mngr_tutor.try_close_tutor("tutor_upgr");
             save_module.save_upgr(this);

--- a/Assets/scripts/global/consts.cs
+++ b/Assets/scripts/global/consts.cs
@@ -58,6 +58,7 @@ public static class consts{
         xp_gps_fraction = 0.2f,
         lvlup_reward_tap_mult = 15f,
         lvlup_reward_gps_mult = 20f,
+        xp_purchase_fraction = 0.1f,
 
         //tap
         st_tap_price = 30f,

--- a/Assets/scripts/global/save_module.cs
+++ b/Assets/scripts/global/save_module.cs
@@ -20,7 +20,7 @@ public static class save_module{
                 elapsed_t += Time.deltaTime;
             }
             if (CrazySDK.IsInitialized){
-                CrazySDK.Data.DeleteAll();
+                //CrazySDK.Data.DeleteAll();
                 save_module.call_restores();
 
                 statics.mngr_tempering.init_after_save_restore();

--- a/Assets/scripts/global/save_module.cs
+++ b/Assets/scripts/global/save_module.cs
@@ -20,7 +20,7 @@ public static class save_module{
                 elapsed_t += Time.deltaTime;
             }
             if (CrazySDK.IsInitialized){
-                //CrazySDK.Data.DeleteAll();
+                CrazySDK.Data.DeleteAll();
                 save_module.call_restores();
 
                 statics.mngr_tempering.init_after_save_restore();

--- a/Assets/scripts/global/statics.cs
+++ b/Assets/scripts/global/statics.cs
@@ -1667,7 +1667,7 @@ public static class statics{
 
                 float xp_reward = price_old_temp * consts.xp_purchase_fraction;
                 if (xp_reward > 0f){
-                    mngr_xp.add(xp_reward);
+                    mngr_xp.add((float)Math.Truncate(xp_reward));
                     mngr_xp.act_ui();
                 }
 

--- a/Assets/scripts/global/statics.cs
+++ b/Assets/scripts/global/statics.cs
@@ -1665,6 +1665,12 @@ public static class statics{
                 statics.mngr_balance.amount -= price_old_temp;
                 statics.mngr_balance.on_val_change();
 
+                float xp_reward = price_old_temp * consts.xp_purchase_fraction;
+                if (xp_reward > 0f){
+                    mngr_xp.add(xp_reward);
+                    mngr_xp.act_ui();
+                }
+
                 save_module.save_tap();
 
                 mngr_tutor.try_close_tutor("tutor_tap");


### PR DESCRIPTION
## Summary
- award experience for passive chocolate upgrades and tap upgrades based on a configurable fraction of the spent chocolate
- expose the XP purchase fraction as a constant in the shared configuration

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d5330c0e248322bfaffb6913459552