### PR TITLE
Prevent golden chocolates from spawning too close to mask edges

### DIFF
--- a/Assets/Scenes/chocolate_clicker.unity
+++ b/Assets/Scenes/chocolate_clicker.unity
@@ -15245,6 +15245,7 @@ GameObject:
   - component: {fileID: 978811556}
   - component: {fileID: 978811559}
   - component: {fileID: 978811557}
+  - component: {fileID: 978811560}
   m_Layer: 5
   m_Name: goldenchocozone
   m_TagString: Untagged
@@ -15309,6 +15310,19 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 978811555}
   m_CullTransparentMesh: 1
+--- !u!114 &978811560
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 978811555}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 31a19414c41e5ae4aae2af33fee712f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ShowMaskGraphic: 1
 --- !u!1 &980756250
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/scripts/global/statics.cs
+++ b/Assets/scripts/global/statics.cs
@@ -857,8 +857,9 @@ public static class statics{
             if (behaviour == null)
                 behaviour = go.AddComponent<golden_chocolate_behaviour>();
 
-            float half_width = rect.rect.width * rect.localScale.x / 2f;
-            float half_height = rect.rect.height * rect.localScale.y / 2f;
+            float half_width = rect.rect.width * rect.localScale.x * 0.5f;
+            float half_height = rect.rect.height * rect.localScale.y * 0.5f;
+            float half_diagonal = Mathf.Sqrt(half_width * half_width + half_height * half_height);
 
             float left_edge = -parent_rect.rect.width * parent_rect.pivot.x;
             float right_edge = parent_rect.rect.width * (1f - parent_rect.pivot.x);
@@ -866,8 +867,8 @@ public static class statics{
             float top_edge = parent_rect.rect.height * (1f - parent_rect.pivot.y);
 
             float spawn_x = left_edge - half_width;
-            float min_y = bottom_edge + half_height;
-            float max_y = top_edge - half_height;
+            float min_y = bottom_edge + half_diagonal;
+            float max_y = top_edge - half_diagonal;
             float spawn_y = (max_y > min_y)
                 ? UnityEngine.Random.Range(min_y, max_y)
                 : (min_y + max_y) * 0.5f;


### PR DESCRIPTION
## Summary
- adjust the golden chocolate spawn logic to respect the full rotated bounds of the prefab
- ensure the spawn range accounts for rotation so chocolates no longer clip against the mask edges

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68d5393658648322a2d13a2e119c85fb